### PR TITLE
fix: Promise returned from `compiler.$windyCSSService.init()` shouldn't be thrown away

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -217,7 +217,7 @@ class WindiCSSWebpackPlugin {
         // Scans all files and builds initial css
         // wrap in a try catch
         try {
-          compiler.$windyCSSService.init()
+          await compiler.$windyCSSService.init()
         } catch (e) {
           compiler.$windyCSSService.initException = e
         }


### PR DESCRIPTION
# Description

Promise returned from `compiler.$windyCSSService.init()` is neither directly awaited nor returned by the function so that the caller function can await it, therefore it has no effect on runtime. Another issue is that the `try...catch` block will not catch any errors thrown by the Promise since it isn't awaited.

https://github.com/windicss/windicss-webpack-plugin/blob/6c1ba0c71a98cab5de07d896e9c140dc8e10c9b7/src/plugin.ts#L219-L223

# Reproduction
I discovered this issue when trying to make the plugin work on a Gatsby site running `gatsby@3.1.2` and `webpack@5.28.0` but I think this should affect all other webpack setups as well not just Gatsby. Could be related to #11  #12

**Error thrown by Webpack**
```
Error: Compiling RuleSet failed: Evaluation of condition function threw error (at ruleSet[1].rules[12].include: include(resource) {
                      var _a, _b;
                      const relativeResource = upath_1.relative(root, resource);
                      _a = compiler.$windyCSSService
                      // Exclude virtual module
                      if (resource.endsWith(constants_1.MODULE_ID_VIRTUAL) || ((_a = compiler.$windyCSSService) === null || _a === void 0 ? void 0 : _a.isExclud
  ed(relativeResource))) {
                          return false;
                      }
                      return Boolean((_b = compiler.$windyCSSService) === null || _b === void 0 ? void 0 : _b.isCssTransformTarget(relativeResource));
                  })
  
  - RuleSetCompiler.js:373 RuleSetCompiler.error
    [example]/[webpack@5.28.0]/[webpack]/lib/rules/RuleSetCompiler.js:373:10

```

