### PR TITLE
fix: undefined loader is added into module.rules

### DIFF
--- a/src/loaders/pitcher.ts
+++ b/src/loaders/pitcher.ts
@@ -32,7 +32,9 @@ export const pitch = function (this: webpack.loader.LoaderContext, remainingRequ
         this.loaders.splice(templateLoaderIndex, 1)
       }
       // re-insert the template-loader in the right spot
-      this.loaders.splice(insertIndex + 1, 0, templateLoader)
+      if (templateLoader) {
+        this.loaders.splice(insertIndex + 1, 0, templateLoader)
+      }
     }
   }
 }


### PR DESCRIPTION
In Nuxt.js build with docus, we're setting error `ERROR  TypeError: Cannot read property 'request' of undefined`, I found templateLoader is undefined but got added to webpack module.rules, so webpack is reading request from undefined load which will fail the build, this pr is adding not-null checking when insert templateLoader to module.rules