### PR TITLE
fix: vue sfc custom block error

### DIFF
--- a/src/loaders/pitcher.ts
+++ b/src/loaders/pitcher.ts
@@ -10,11 +10,16 @@ const isPitcherLoader = (l: { ident?: string }) => `${NAME}:pitcher` === l.ident
   *
   * We move it just after the PostCSS loader
   */
-export const pitch = function(this: webpack.loader.LoaderContext, remainingRequest: string) {
+export const pitch = function (this: webpack.loader.LoaderContext, remainingRequest: string) {
   // remove the pitcher immediately
   const pitcherLoaderIndex = this.loaders.findIndex(isPitcherLoader)
   if (pitcherLoaderIndex !== -1)
     this.loaders.splice(pitcherLoaderIndex, 1)
+
+  // ignore custom block 
+  if (remainingRequest.includes('&type=custom')) {
+    return ``;
+  }
 
   // make sure we're dealing with style-loader
   if (!remainingRequest.includes('&type=style'))


### PR DESCRIPTION
`/loaders/transform-template.js` will cause the logic of the custom block of `vue-loader` to ignore: 

![image](https://user-images.githubusercontent.com/20717402/142267378-0dc42676-d573-4bb4-ac45-7e384f6d69d0.png)

Cause compilation failure.