### PR TITLE
fix: remove transformedCSS <style> wrap

### DIFF
--- a/src/loaders/windicss-template.ts
+++ b/src/loaders/windicss-template.ts
@@ -78,7 +78,7 @@ function WindicssTemplate(
         return def(transformedCSS, match)
       }
       const transformedCSS = transformCSS(service, css, this.resource)
-      return `<style${meta}>\n${transformedCSS}\n</style>`
+      return `<style${meta}>${transformedCSS}</style>`
     })
     debug.loader('Transformed template ', this.resource)
     const transformed = service.transformGroups(templateWithTransformedCSS)


### PR DESCRIPTION
`<style${meta}>\n${transformedCSS}\n</style>`

This writing breaks the source structure, resulting in generated hash inconsistencies, resulting in incorrect scopeId matching in vue。

so, I remove '\n' in `<style${meta}>\n${transformedCSS}\n</style>`